### PR TITLE
Use musl builder for statically linked binaries

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,12 +15,14 @@ jobs:
     strategy:
       matrix:
         include:
+          - target: aarch64-apple-darwin
+            os: macos-latest
           - target: x86_64-apple-darwin
             os: macos-latest
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
-          - target: aarch64-apple-darwin
-            os: macos-latest
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/cache@v3
@@ -34,10 +36,23 @@ jobs:
           key: ${{ matrix.target }}-cargo-${{ hashFiles('**/Cargo.lock') }}-${{ hashFiles('**/Cargo.toml') }}
 
       - name: Add rustup target
+        if: matrix.target != 'x86_64-unknown-linux-musl'
         run: rustup target add ${{ matrix.target }}
 
       - name: Build ${{ matrix.target }}
+        if: matrix.target != 'x86_64-unknown-linux-musl'
         run: cargo build --release --target=${{ matrix.target }}
+
+      - name: Build static ${{ matrix.target }}
+        if: matrix.target == 'x86_64-unknown-linux-musl'
+        run: |
+          mkdir -p ~/.cargo/{git,registry}
+          docker run --rm -t \
+              --mount type=bind,source=${{ github.workspace }},target=/volume \
+              --mount type=bind,source=$HOME/.cargo/registry,target=/root/.cargo/registry \
+              --mount type=bind,source=$HOME/.cargo/git,target=/root/.cargo/git \
+              clux/muslrust:stable \
+              cargo build --release
 
       - name: Create tar.gz
         run: tar -czvf tfreg_${{ matrix.target }}.tar.gz -C target/${{ matrix.target }}/release tfreg


### PR DESCRIPTION
The linux gnu binaries require a recent version of glibc since they're built on the `ubuntu-latest` builder. We _could_ build on an older version of ubuntu, but that still only partially solves the issue.

Instead, build a fully static binary with the https://github.com/clux/muslrust project.